### PR TITLE
Changed country codes to use ISO 3166

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var euList = [
   { country: "Finland", code: "FI", vat: 24 },
   { country: "France", code: "FR", vat: 20 },
   { country: "Germany", code: "DE", vat: 19 },
-  { country: "Greece", code: "EL", vat: 24 },
+  { country: "Greece", code: "GR", vat: 24 },
   { country: "Hungary", code: "HU", vat: 27 },
   { country: "Ireland", code: "IE", vat: 23 },
   { country: "Italy", code: "IT", vat: 22 },
@@ -24,13 +24,13 @@ var euList = [
   { country: "Luxembourg", code: "LU", vat: 17 },
   { country: "Malta", code: "MT", vat: 18 },
   { country: "Netherlands", code: "NL", vat: 21 },
-  { country: "Poland", code: "PO", vat: 23 },
+  { country: "Poland", code: "PL", vat: 23 },
   { country: "Portugal", code: "PT", vat: 23 },
   { country: "Romania", code: "RO", vat: 20 },
   { country: "Slovakia", code: "SK", vat: 20 },
   { country: "Slovenia", code: "SI", vat: 22 },
   { country: "Spain", code: "ES", vat: 21 },
-  { country: "Sweden", code: "SW", vat: 25 },
+  { country: "Sweden", code: "SE", vat: 25 },
   { country: "United Kingdom", code: "GB", vat: 20 }
 ];
 


### PR DESCRIPTION
Stripe API threw errors when trying to create tax rates with previous values.

ISO 3166 seems to be the [correct format](https://stripe.com/docs/api/charges/object#charge_object-billing_details-address-country)